### PR TITLE
Aceptar fecha como parámetro de entrada

### DIFF
--- a/aemetextract.sh
+++ b/aemetextract.sh
@@ -7,7 +7,6 @@
 set -e 
 set -o pipefail
 
-DOS_PUNTOS_URL=%3A
 FORMATO_FECHAS_API='+%Y-%m-%dT00%%3A00%%3A00UTC'
 OUT_FILE=datos.json
 

--- a/aemetextract.sh
+++ b/aemetextract.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Uso: ./aemetextract.sh [FECHA]
+# FECHA es una fecha en formato ISO 8601
+# Si no se especifica se usara la fecha actual
 
 # Aborta mision si un comando falla
 set -e 

--- a/aemetextract.sh
+++ b/aemetextract.sh
@@ -1,9 +1,29 @@
 #!/bin/bash
 
-#ini=2020-12-27T00%3A00%3A00UTC
-#fin=2020-12-31T00%3A00%3A00UTC
+# Aborta mision si un comando falla
+set -e 
+set -o pipefail
 
-curl -X 'GET' \
-  'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/2024-06-01T00%3A00%3A00UTC/fechafin/2024-11-31T00%3A00%3A00UTC/estacion/3191E' \
-  -H 'accept: application/json' \
-  -H 'api_key: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwYWNyOGFjNjc3LTYwMmQtNDkzOS1iMDgyLWQ0MDA5ZDM1MWE5YiIsImlzcyI6IkFFTUVUIiwiaWF0IjoxNjA5NDkxNTIyLCJ1c2VySWQiOiIzMjhhYzY3Ny02MDJkLTQ5MzktYjA4Mi1kNDAwOWQzNTFhOWIiLCJyb2xlIjoiIn0.Ow5zuZbkr3-XTrLVPSfH9L2yDkEtuChdWZHVQ1Yenxc' > prueba.json && jq .datos prueba.json > datos.json && sed -i 's/"//g' datos.json && wget -i datos.json 
+DOS_PUNTOS_URL=%3A
+FORMATO_FECHAS_API='+%Y-%m-%dT00%%3A00%%3A00UTC'
+OUT_FILE=datos.json
+
+# Parametros de la peticion
+FECHA_FIN_API=$(date --date="$1" "$FORMATO_FECHAS_API")
+FECHA_INI_API=$(date --date="$1 - 6 months" "$FORMATO_FECHAS_API")
+ESTACION="3191E"
+API_KEY="eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwYWNyOGFjNjc3LTYwMmQtNDkzOS1iMDgyLWQ0MDA5ZDM1MWE5YiIsImlzcyI6IkFFTUVUIiwiaWF0IjoxNjA5NDkxNTIyLCJ1c2VySWQiOiIzMjhhYzY3Ny02MDJkLTQ5MzktYjA4Mi1kNDAwOWQzNTFhOWIiLCJyb2xlIjoiIn0.Ow5zuZbkr3-XTrLVPSfH9L2yDkEtuChdWZHVQ1Yenxc"
+
+# Solicitud URL de datos via API
+RESPUESTA=$( \
+curl --fail \
+ "https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/$FECHA_INI_API/fechafin/$FECHA_FIN_API/estacion/$ESTACION" \
+ -H 'accept: application/json' \
+ -H "api_key: $API_KEY" \
+)
+
+# Extraccion de URL de datos de la respuesta JSON
+URL_DATOS=$(jq -r --argjson input "$RESPUESTA" -n '$input.datos')
+
+# Descarga de los datos
+wget -O "$OUT_FILE" "$URL_DATOS"


### PR DESCRIPTION
Se añade soporte para aceptar la fecha de fin como parámetro de entrada del script.

La fecha de inicio se establece a 6 meses antes. Las horas se truncan a las 0:00 del día en UTC.

Uso: `./aemetextract.sh 2024-06-22`

Acepta cualquier formato compatible con `date` (`man 1 date`).

Adicionalmente se elimina el fichero intermedio en favor de variables.